### PR TITLE
Remove stray Serial.println() call

### DIFF
--- a/src/uEEPROMLib.cpp
+++ b/src/uEEPROMLib.cpp
@@ -174,7 +174,6 @@ bool uEEPROMLib::eeprom_write(const unsigned int address, void *data, const uint
 	for (i = 0; i < n; i++) {
 		r &= _eeprom_write(address + i, (byte) *(((byte *) data) + i));
 	}
-Serial.println();
 	return r;
 }
 


### PR DESCRIPTION
I just removed a leftover (debug?) Serial.println() call in eeprom_write().