### PR TITLE
_eeprom_read_sub - always write EEPROM page aligned

### DIFF
--- a/examples/uEEPROMLib_example/uEEPROMLib_example.ino
+++ b/examples/uEEPROMLib_example/uEEPROMLib_example.ino
@@ -41,49 +41,49 @@ delay (2000);
 #ifdef ARDUINO_ARCH_AVR
 	int inttmp = 32123;
 #else
-	// too logng for AVR 16 bits!
+	// too long for AVR 16 bits!
 	int inttmp = 24543557;
 #endif
 	float floattmp = 3.1416;
 	char chartmp = 'A';
 
-    char c_string[128] = "abcdefghijklmnopqrstuvwxyz1234567890!@#$%^&*()";
+    char c_string[128] = "abcdefghijklmnopqrstuvwxyz1234567890!@#$%^&*()ABCDEFGHIJKLMNOPQ";
 
-  if (!eeprom.eeprom_write(8, chartmp)) {
-    Serial.println("Failed to store CHAR");
-  } else {
-    Serial.println("CHAR correctly stored");
-  }
+	// Write single char at address 
+	if (!eeprom.eeprom_write(8, chartmp)) {
+	Serial.println("Failed to store CHAR");
+	} else {
+	Serial.println("CHAR correctly stored");
+	}
 
-  if (!eeprom.eeprom_write(33, (byte *) c_string, strlen(c_string))) {
-    Serial.println("Failed to store STRING");
-  } else {
-    Serial.println("STRING correctly stored");
-  }
+	// Write a long string of chars FROM position 33 which isn't aligned to the 32 byte pages of the EEPROM
+	if (!eeprom.eeprom_write(33, (byte *) c_string, strlen(c_string))) {
+	Serial.println("Failed to store STRING");
+	} else {
+	Serial.println("STRING correctly stored");
+	}
 
-
-	// Testing template
+	// Write an int
 	if (!eeprom.eeprom_write(0, inttmp)) {
 		Serial.println("Failed to store INT");
 	} else {
 		Serial.println("INT correctly stored");
 	}
 
+	// write a float
 	if (!eeprom.eeprom_write(4, floattmp)) {
 		Serial.println("Failed to store FLOAT");
 	} else {
 		Serial.println("FLOAT correctly stored");
 	}
 
-	inttmp = 0;
-	floattmp = 0;
-	chartmp = 0;
+	// Flush
+	inttmp = floattmp = chartmp = 0;
 
-  Serial.print("C string length is: "); Serial.println(sizeof(c_string), DEC);
-  memset(c_string,0,sizeof(c_string));
+	Serial.print("C string length is: "); Serial.println(sizeof(c_string), DEC);
+	memset(c_string,0,sizeof(c_string));
 
-
-
+	
 	Serial.print("int: ");
 	eeprom.eeprom_read(0, &inttmp);
 	Serial.println(inttmp);
@@ -97,14 +97,12 @@ delay (2000);
 	Serial.println(chartmp);
 
 	Serial.print("chararray: ");
-	eeprom.eeprom_read(33, (byte *) c_string, 41);
+	eeprom.eeprom_read(33, (byte *) c_string, sizeof(c_string));
 	Serial.println(c_string);
 
 	Serial.println();
+	Serial.println("Printing value of each EEPROM address in HEX....");
 
-	for(pos = 26; pos < 1000; pos++) {
-		eeprom.eeprom_write(pos, (unsigned char) (pos % 256));
-	}
 
 	pos = 0;
  
@@ -113,13 +111,12 @@ delay (2000);
 void loop() {
   
 	Serial.print(pos);
-	Serial.print(": ");
-	Serial.print(eeprom.eeprom_read(pos));
+	Serial.print(": 0x");
+	Serial.print(eeprom.eeprom_read(pos), HEX);
 
 	Serial.println();
 
 	pos++;
-	pos %= 1000;
-	delay(1000);
+	delay(500);
 
 }

--- a/examples/uEEPROMLib_example/uEEPROMLib_example.ino
+++ b/examples/uEEPROMLib_example/uEEPROMLib_example.ino
@@ -47,8 +47,9 @@ delay (2000);
 	float floattmp = 3.1416;
 	char chartmp = 'A';
 
-    char c_string[128] = "abcdefghijklmnopqrstuvwxyz1234567890!@#$%^&*()ABCDEFGHIJKLMNOPQ";
-
+  char c_string[128] = "abcdefghijklmnopqrstuvwxyz1234567890!@#$%^&*()ABCDEFGHIJKLMNOPQ";
+  int string_length = strlen(c_string);
+  
 	// Write single char at address 
 	if (!eeprom.eeprom_write(8, chartmp)) {
 	Serial.println("Failed to store CHAR");
@@ -80,7 +81,7 @@ delay (2000);
 	// Flush
 	inttmp = floattmp = chartmp = 0;
 
-	Serial.print("C string length is: "); Serial.println(sizeof(c_string), DEC);
+	Serial.print("C string length is: "); Serial.println(string_length, DEC);
 	memset(c_string,0,sizeof(c_string));
 
 	
@@ -97,7 +98,7 @@ delay (2000);
 	Serial.println(chartmp);
 
 	Serial.print("chararray: ");
-	eeprom.eeprom_read(33, (byte *) c_string, sizeof(c_string));
+	eeprom.eeprom_read(33, (byte *) c_string, string_length);
 	Serial.println(c_string);
 
 	Serial.println();

--- a/examples/uEEPROMLib_example/uEEPROMLib_example.ino
+++ b/examples/uEEPROMLib_example/uEEPROMLib_example.ino
@@ -25,14 +25,14 @@ unsigned int pos;
 
 void setup() {
 delay (2000);
-	Serial.begin(9600);
+	Serial.begin(115200);
     Serial.println("Serial OK");
 
 	delay(2500);
 	Serial.println("Delay OK");
 
 	#ifdef ARDUINO_ARCH_ESP8266
-		Wire.begin(0, 2); // D3 and D4 on ESP8266
+		Wire.begin(4, 5); // D3 and D4 on ESP8266
 	#else
 		Wire.begin();
 	#endif
@@ -47,7 +47,19 @@ delay (2000);
 	float floattmp = 3.1416;
 	char chartmp = 'A';
 
-    char string[17] = "ForoElectro.Net\0";
+    char c_string[128] = "abcdefghijklmnopqrstuvwxyz1234567890!@#$%^&*()";
+
+  if (!eeprom.eeprom_write(8, chartmp)) {
+    Serial.println("Failed to store CHAR");
+  } else {
+    Serial.println("CHAR correctly stored");
+  }
+
+  if (!eeprom.eeprom_write(33, (byte *) c_string, strlen(c_string))) {
+    Serial.println("Failed to store STRING");
+  } else {
+    Serial.println("STRING correctly stored");
+  }
 
 
 	// Testing template
@@ -56,27 +68,19 @@ delay (2000);
 	} else {
 		Serial.println("INT correctly stored");
 	}
+
 	if (!eeprom.eeprom_write(4, floattmp)) {
 		Serial.println("Failed to store FLOAT");
 	} else {
 		Serial.println("FLOAT correctly stored");
 	}
-	if (!eeprom.eeprom_write(8, chartmp)) {
-		Serial.println("Failed to store CHAR");
-	} else {
-		Serial.println("CHAR correctly stored");
-	}
-
-	if (!eeprom.eeprom_write(9, (byte *) &string[0], 16)) {
-		Serial.println("Failed to store STRING");
-	} else {
-		Serial.println("STRING correctly stored");
-	}
 
 	inttmp = 0;
 	floattmp = 0;
 	chartmp = 0;
-    string[0] = string[1] = string[2] = string[3] = string[4] = 0;
+
+  Serial.print("C string length is: "); Serial.println(sizeof(c_string), DEC);
+  memset(c_string,0,sizeof(c_string));
 
 
 
@@ -93,20 +97,21 @@ delay (2000);
 	Serial.println(chartmp);
 
 	Serial.print("chararray: ");
-	eeprom.eeprom_read(9, (byte *) &string[0], 16);
-	Serial.println(string);
+	eeprom.eeprom_read(33, (byte *) c_string, 41);
+	Serial.println(c_string);
 
 	Serial.println();
-
 
 	for(pos = 26; pos < 1000; pos++) {
 		eeprom.eeprom_write(pos, (unsigned char) (pos % 256));
 	}
 
 	pos = 0;
+ 
 }
 
 void loop() {
+  
 	Serial.print(pos);
 	Serial.print(": ");
 	Serial.print(eeprom.eeprom_read(pos));
@@ -116,4 +121,5 @@ void loop() {
 	pos++;
 	pos %= 1000;
 	delay(1000);
+
 }

--- a/examples/uEEPROMLib_page_write/uEEPROMLib_page_write.ino
+++ b/examples/uEEPROMLib_page_write/uEEPROMLib_page_write.ino
@@ -20,30 +20,30 @@
 uEEPROMLib eeprom(0x57);
 
 // 305 bytes
-char longMessage[310] = "I2C EEPROM library example. Split from uRTCLib\n\nThis library controls any I2C EEPROM, independent ones or incorporated on DS1307 or DS3231 RTCs.\n\nhttps://github.com/Naguissa/uEEPROMLib\nhttps://www.foroelectro.net/librerias-arduino-ide-f29/ueepromlib-arduino-libreria-simple-y-eficaz-para-e-t225.html\0";
+char longMessage[512] = "I2C EEPROM library example. Split from uRTCLib\n\nThis library controls any I2C EEPROM, independent ones or incorporated on DS1307 or DS3231 RTCs.\n\nhttps://github.com/Naguissa/uEEPROMLib\nhttps://www.foroelectro.net/librerias-arduino-ide-f29/ueepromlib-arduino-libreria-simple-y-eficaz-para-e-t225.html\0";
 
 void setup() {
 delay (2000);
-	Serial.begin(9600);
+	Serial.begin(115200);
     Serial.println("Serial OK");
 
 	delay(2500);
 	Serial.println("Delay OK");
 
 	#ifdef ARDUINO_ARCH_ESP8266
-		Wire.begin(0, 2); // D3 and D4 on ESP8266
+		Wire.begin(4, 5); // D3 and D4 on ESP8266
 	#else
 		Wire.begin();
 	#endif
 
 	// Alligned
-	if (!eeprom.eeprom_write(0, (byte *) &longMessage[0], 305)) {
+	if (!eeprom.eeprom_write(0, (byte *) longMessage, strlen(longMessage))) {
 		Serial.println("Failed to store aligned STRING");
 	} else {
 		Serial.println("Aligned STRING correctly stored");
 	}
 
-	if (!eeprom.eeprom_write(311, (byte *) &longMessage[0], 305)) {
+	if (!eeprom.eeprom_write(500, (byte *) longMessage, strlen(longMessage))) {
 		Serial.println("Failed to store unaligned STRING");
 	} else {
 		Serial.println("Unaligned STRING correctly stored");
@@ -54,19 +54,19 @@ delay (2000);
 void loop() {
 	char *readMessageA;
 	char *readMessageB;
-	readMessageA = (char * ) malloc(210);
-	readMessageB = (char * ) malloc(210);
+	readMessageA = (char * ) malloc(512);
+	readMessageB = (char * ) malloc(512);
 	Serial.println("-------------------------------------");
 	Serial.println();
 
 	Serial.println("Algined string:");
-	eeprom.eeprom_read(0, (byte *) readMessageA, 305);
+	eeprom.eeprom_read(0, (byte *) readMessageA, 500);
 	Serial.println(readMessageA);
 
 	Serial.println();
 
 	Serial.println("Unalgined string:");
-	eeprom.eeprom_read(0, (byte *) readMessageB, 305);
+	eeprom.eeprom_read(0, (byte *) readMessageB, 500);
 	Serial.println(longMessage);
 
 	Serial.println();

--- a/examples/uEEPROMLib_page_write/uEEPROMLib_page_write.ino
+++ b/examples/uEEPROMLib_page_write/uEEPROMLib_page_write.ino
@@ -22,21 +22,71 @@ uEEPROMLib eeprom(0x57);
 // 305 bytes
 char longMessage[512] = "I2C EEPROM library example. Split from uRTCLib\n\nThis library controls any I2C EEPROM, independent ones or incorporated on DS1307 or DS3231 RTCs.\n\nhttps://github.com/Naguissa/uEEPROMLib\nhttps://www.foroelectro.net/librerias-arduino-ide-f29/ueepromlib-arduino-libreria-simple-y-eficaz-para-e-t225.html\0";
 
-void setup() {
-delay (2000);
+void setup() {  
+  delay (2000);
 	Serial.begin(115200);
-    Serial.println("Serial OK");
+  Serial.println("Serial OK");
 
-	delay(2500);
-	Serial.println("Delay OK");
-
+ 
 	#ifdef ARDUINO_ARCH_ESP8266
 		Wire.begin(4, 5); // D3 and D4 on ESP8266
 	#else
 		Wire.begin();
 	#endif
 
-	// Alligned
+
+	#ifdef ARDUINO_ARCH_ESP8266 || ARDUINO_ARCH_ESP32
+	
+	byte 	    random_numbers[1027]; // write 1027 bytes of random data
+	uint16_t 	random_number = 0;
+	uint16_t 	running_total = 0;
+  int       eeprom_start_address = 123; // random
+	Serial.println("Performing FULL EEPROM write test and verify with library - page writes (32 bytes at a time)");
+	
+	for (int i = 0; i < sizeof(random_numbers); i++)
+	{
+		random_number = rand() % 10 + 1; // range from 1 to 10
+		random_numbers[i] = random_number;
+		running_total += random_number;
+	}
+
+	Serial.print("Magic number: "); Serial.println(running_total, DEC);	
+	
+	Serial.println("Writing 1kB to EEPROM.");
+	if (!eeprom.eeprom_write(eeprom_start_address, (byte *) random_numbers, sizeof(random_numbers))) {
+		Serial.println("Failed to write to EEPROM!");
+	} 
+	
+	delay(1000);
+	random_number = 0;
+	memset(random_numbers,0, sizeof(random_numbers));	// Flush back to zero		
+	Serial.println("Reading 1kB from EEPROM....");
+	eeprom.eeprom_read(eeprom_start_address, (byte *) random_numbers, sizeof(random_numbers));	
+	
+	for (int i = 0; i < sizeof(random_numbers); i++)
+	{
+    //Serial.print("Read from magic number array value: "); Serial.println (random_numbers[i], DEC);
+		random_number += random_numbers[i];
+	}	
+
+  Serial.print("Calculated magic number: "); Serial.println(random_number, DEC);
+	
+	if ( random_number == running_total)
+	{
+		Serial.println("Magic numbers match. EEPROM read successful.");
+	}
+ else
+ {
+    Serial.println("==> VALIDATION ERROR <==");
+ }
+ 
+	
+	#endif
+
+
+	
+
+	// Aligned String vs Unaligned
 	if (!eeprom.eeprom_write(0, (byte *) longMessage, strlen(longMessage))) {
 		Serial.println("Failed to store aligned STRING");
 	} else {
@@ -49,25 +99,30 @@ delay (2000);
 		Serial.println("Unaligned STRING correctly stored");
 	}
 
+  char *readMessageA;
+  char *readMessageB;
+  readMessageA = (char * ) malloc(512);
+  readMessageB = (char * ) malloc(512);
+  Serial.println("-------------------------------------");
+  Serial.println();
+
+  Serial.println("Page Aligned string (offset: 0):");
+  eeprom.eeprom_read(0, (byte *) readMessageA, strlen(longMessage));
+  Serial.println(readMessageA);
+
+  Serial.println();
+
+  Serial.println("Page Unaligned string (offset: 500):");
+  eeprom.eeprom_read(500, (byte *) readMessageB, strlen(longMessage));
+  Serial.println(readMessageB);
+
+  Serial.println();
+
+  Serial.println("-------------------------------------");
+   
+
 }
 
 void loop() {
-	char *readMessageA;
-	char *readMessageB;
-	readMessageA = (char * ) malloc(512);
-	readMessageB = (char * ) malloc(512);
-	Serial.println("-------------------------------------");
-	Serial.println();
-
-	Serial.println("Algined string:");
-	eeprom.eeprom_read(0, (byte *) readMessageA, 500);
-	Serial.println(readMessageA);
-
-	Serial.println();
-
-	Serial.println("Unalgined string:");
-	eeprom.eeprom_read(0, (byte *) readMessageB, 500);
-	Serial.println(longMessage);
-
-	Serial.println();
+	
 }

--- a/src/uEEPROMLib.h
+++ b/src/uEEPROMLib.h
@@ -58,6 +58,12 @@
 	 * \brief Wire very short delay - needed to give time to EEPROM to process Wire requests
 	 */
 	#define uEEPROMLIB_WIRE_SHORT_DELAY 1
+	
+	/**
+	 * \Serial Debug - To see what's going on in the library
+	 */	
+	 //#define uEEPROMLIB_DEBUG 1
+	
 
 
 

--- a/src/uEEPROMLib.h
+++ b/src/uEEPROMLib.h
@@ -86,11 +86,14 @@
 			bool eeprom_write(const unsigned int, char);
 			bool eeprom_write(const unsigned int, unsigned char);
  			template <typename TW> bool eeprom_write(const unsigned int, const TW);
+			
 		private:
 			bool _eeprom_read_sub(const unsigned int, byte *, const uint8_t);
 			bool _eeprom_write_sub(const unsigned int, byte *, const uint8_t);
-			// Adresses
-			int _ee_address = UEEPROMLIB_ADDRESS;
+			
+			// Addresses
+			int _ee_address = UEEPROMLIB_ADDRESS; 
+			
 			// EEPROM read and write private functions - works with bytes
 			byte _eeprom_read(const unsigned int);
 			bool _eeprom_write(const unsigned int, const byte);
@@ -100,7 +103,7 @@
 	};
 
 
-	// Templates must be here because Arduino compiler incoptability to declare them on .cpp fil
+	// Templates must be here because Arduino compiler incompatibility to declare them on .cpp file
 
 	/**
 	 *


### PR DESCRIPTION
Rewrite examples and eeprom_write function such that it will always write to the page size (32 bytes) and in increments less than the arduinos 32 byte I2C buffer.

Aligned or unaligned page write work the same.